### PR TITLE
404 json instead of html

### DIFF
--- a/brackend/app.py
+++ b/brackend/app.py
@@ -117,5 +117,10 @@ def makeBracketFromEntrants():
     return jsonify(rounds=matches)
 
 
+@app.errorhandler(404)
+def route_not_found(e):
+    return jsonify({"error": "Resource not found"}), 404
+
+
 if __name__ == "__main__":
     app.run(host="0.0.0.0")


### PR DESCRIPTION
Makes it easier to debug when we hit wrong endpoints from the app, so the json is still parsed