### PR TITLE
simple LIKE search for tournamentS

### DIFF
--- a/brackend/endpoints/tournaments/repositories/TournamentRepository.py
+++ b/brackend/endpoints/tournaments/repositories/TournamentRepository.py
@@ -1,0 +1,22 @@
+from abc import ABC
+from sqlalchemy.orm import Session
+from brackend.db.models import (
+    EngineGetter,
+    Tournament,
+)
+
+
+class TournamentRepository(ABC):
+    engine = EngineGetter.get_or_create_engine()
+
+    @classmethod
+    def search_by_name(cls, name, count=20):
+        with Session(cls.engine) as session:
+            search = "%{}%".format(name)
+            results = session.query(Tournament)\
+                .filter(Tournament.name.like(search))\
+                .limit(count)\
+                .all()
+            return results
+
+

--- a/brackend/endpoints/tournaments/tournaments.py
+++ b/brackend/endpoints/tournaments/tournaments.py
@@ -3,6 +3,7 @@ from flask_restful import Api, Resource
 
 from brackend.tasks.auth import requires_auth
 from brackend.tasks.tasks import get_tournament_by_id, save_new_tournament, get_tournaments_by_uid
+from brackend.endpoints.tournaments.repositories.TournamentRepository import TournamentRepository
 
 tournament_bp = Blueprint("tournaments", __name__)
 tournament_api = Api(tournament_bp)
@@ -32,5 +33,18 @@ class TournamentDetails(Resource):
         return jsonify(tourny.to_json())
 
 
+@requires_auth
+class TournamentSearch(Resource):
+    """Get info for specific tournament, by id."""
+
+    def post(self):
+        body = request.get_json()
+        name = body.get("name")
+        # TODO: Eventually search by short id code
+        results = TournamentRepository.search_by_name(name)
+        return jsonify(results=[result.to_json() for result in results])
+
+
 tournament_api.add_resource(Tournaments, "/tournaments")
+tournament_api.add_resource(TournamentSearch, "/tournaments/search")
 tournament_api.add_resource(TournamentDetails, "/tournaments/<string:tournament_id>")


### PR DESCRIPTION
Search for tournaments by a simple LIKE query. This is obviously not a long term solution, but really should be fine until there are thousands and thousands of tournaments

Things to follow up with:
- Only search tournaments the user has access to (i.e. only public tournaments when we eventually add private/public)
- Search by code once we have id codes
