### PR TITLE
just go ahead and return owner info whenever getting tournament details

### DIFF
--- a/brackend/db/models.py
+++ b/brackend/db/models.py
@@ -44,11 +44,23 @@ class Tournament(Base):
     users = association_proxy("user_tournaments", "user")
     brackets = relationship("Bracket", backref="tournaments")
 
+    def __init__(self, data):
+        super.__init__(self, data)
+        self.owner = None
+
     def __repr__(self):
         return f"Tournament(id={self.id}, name={self.name})"
 
+    def add_owner_info(self, data):
+        self.owner = data
+
     def to_json(self):
-        return {"name": self.name, "id": self.id, "brackets": [b.to_json() for b in self.brackets]}
+        return {
+            "name": self.name,
+            "id": self.id,
+            "brackets": [b.to_json() for b in self.brackets],
+            "owner": self.owner.to_json()
+        }
 
 
 class UserTournament(Base):

--- a/brackend/endpoints/brackets/brackets.py
+++ b/brackend/endpoints/brackets/brackets.py
@@ -18,8 +18,8 @@ class Brackets(Resource):
         tournament_id = body.get("tournament")
 
         # Validate that this user owns the tournament they are attempting to add a bracket to
-        tournament, owner = TournamentRepository.get_by_id_with_owner(tournament_id)
-        if g.user.id != owner.id:
+        tournament = TournamentRepository.get_by_id(tournament_id)
+        if g.user.id != tournament.owner.id:
             raise BrackendException("Tournament does not belong to user")
         data = {
             "tournament": body.get("tournament"),
@@ -39,8 +39,8 @@ class BracketDetails(Resource):
 
     def delete(self, bracket_id):
         bracket = BracketRepository.get_by_id(bracket_id)
-        tournament, owner = TournamentRepository.get_by_id_with_owner(bracket.tournament)
-        if g.user.id != owner.id:
+        tournament = TournamentRepository.get_by_id(bracket.tournament)
+        if g.user.id != tournament.owner.id:
             raise BrackendException("Tournament does not belong to user")
         deleted = BracketRepository.delete(bracket_id)
         return jsonify(deleted.to_json())

--- a/brackend/endpoints/tournaments/repositories/TournamentRepository.py
+++ b/brackend/endpoints/tournaments/repositories/TournamentRepository.py
@@ -13,16 +13,6 @@ class TournamentRepository(ABC):
     engine = EngineGetter.get_or_create_engine()
 
     @classmethod
-    def get_by_id(cls, t_id):
-        with Session(cls.engine) as session:
-            tournament = session.query(Tournament) \
-                .options(subqueryload(Tournament.brackets)) \
-                .filter(Tournament.id == t_id) \
-                .one_or_none()
-
-            return tournament
-
-    @classmethod
     def get_all_for_user(cls, user):
         with Session(cls.engine) as session:
             tournaments = session.query(Tournament) \
@@ -34,12 +24,13 @@ class TournamentRepository(ABC):
             return tournaments
 
     @classmethod
-    def get_by_id_with_owner(cls, t_id):
+    def get_by_id(cls, t_id):
         """
             Return a tournament with it's owner info
         """
         with Session(cls.engine) as session:
             result = session.query(Tournament, User) \
+                .options(subqueryload(Tournament.brackets)) \
                 .join(UserTournament, Tournament.id == UserTournament.tournament_id) \
                 .join(User, User.id == UserTournament.user_id) \
                 .filter(Tournament.id == t_id) \
@@ -49,7 +40,9 @@ class TournamentRepository(ABC):
             tournament = result[0][0]
             owner = result[0][1]
 
-            return tournament, owner
+            tournament.add_owner_info(owner)
+
+            return tournament
 
     @classmethod
     def search_by_name(cls, name, count=20):


### PR DESCRIPTION
Some changes to just always return owner with a tournament. 

### `GET /api/v1/tournaments/:id`
Response:
```
{
    "brackets": [
        {
            "id": 1,
            "name": "test",
            "participants": [],
            "tournament": 266
        },
        {
            "id": 37,
            "name": "Second tier",
            "participants": [],
            "tournament": 266
        }
    ],
    "id": 266,
    "name": "My First Tournament",
    "owner": {
        "firebase_id": "hntiH5mW2yStuHqoF3KvZ2CDK7p1",
        "username": "User_good"
    }
}
```